### PR TITLE
Fix Motor3D geometric antiproduct

### DIFF
--- a/TSMotor3D.cpp
+++ b/TSMotor3D.cpp
@@ -172,9 +172,9 @@ Motor3D Terathon::operator *(const Motor3D& a, const Motor3D& b)
 	                a.v.w * b.v.y + a.v.y * b.v.w + a.v.z * b.v.x - a.v.x * b.v.z,
 	                a.v.w * b.v.z + a.v.z * b.v.w + a.v.x * b.v.y - a.v.y * b.v.x,
 	                a.v.w * b.v.w - a.v.x * b.v.x - a.v.y * b.v.y - a.v.z * b.v.z,
-	                a.m.w * b.v.z + a.m.x * b.v.y - a.m.y * b.v.x + a.m.z * b.v.w + b.m.w * a.v.z - b.m.x * a.v.y + b.m.y * a.v.x + b.m.z * a.v.w,
 	                a.m.w * b.v.x + a.m.x * b.v.w + a.m.y * b.v.z - a.m.z * b.v.y + b.m.w * a.v.x + b.m.x * a.v.w - b.m.y * a.v.z + b.m.z * a.v.y,
 	                a.m.w * b.v.y - a.m.x * b.v.z + a.m.y * b.v.w + a.m.z * b.v.x + b.m.w * a.v.y + b.m.x * a.v.z + b.m.y * a.v.w - b.m.z * a.v.x,
+	                a.m.w * b.v.z + a.m.x * b.v.y - a.m.y * b.v.x + a.m.z * b.v.w + b.m.w * a.v.z - b.m.x * a.v.y + b.m.y * a.v.x + b.m.z * a.v.w,
 	                a.m.w * b.v.w - a.m.x * b.v.x - a.m.y * b.v.y - a.m.z * b.v.z + b.m.w * a.v.w - b.m.x * a.v.x - b.m.y * a.v.y - b.m.z * a.v.z));
 }
 
@@ -184,9 +184,9 @@ Motor3D Terathon::operator *(const Motor3D& Q, const Quaternion& r)
 	                Q.v.w * r.y - Q.v.x * r.z + Q.v.y * r.w + Q.v.z * r.x,
 	                Q.v.w * r.z + Q.v.x * r.y - Q.v.y * r.x + Q.v.z * r.w,
 	                Q.v.w * r.w - Q.v.x * r.x - Q.v.y * r.y - Q.v.z * r.z,
-	                Q.m.w * r.z + Q.m.x * r.y - Q.m.y * r.x + Q.m.z * r.w,
 	                Q.m.w * r.x + Q.m.x * r.w + Q.m.y * r.z - Q.m.z * r.y,
 	                Q.m.w * r.y - Q.m.x * r.z + Q.m.y * r.w + Q.m.z * r.x,
+	                Q.m.w * r.z + Q.m.x * r.y - Q.m.y * r.x + Q.m.z * r.w,
 	                Q.m.w * r.w - Q.m.x * r.x - Q.m.y * r.y - Q.m.z * r.z));
 }
 
@@ -196,9 +196,9 @@ Motor3D Terathon::operator *(const Quaternion& r, const Motor3D& Q)
 	                r.w * Q.v.y - r.x * Q.v.z + r.y * Q.v.w + r.z * Q.v.x,
 	                r.w * Q.v.z + r.x * Q.v.y - r.y * Q.v.x + r.z * Q.v.w,
 	                r.w * Q.v.w - r.x * Q.v.x - r.y * Q.v.y - r.z * Q.v.z,
-	                r.w * Q.m.z + r.x * Q.m.y - r.y * Q.m.x + r.z * Q.m.w,
 	                r.w * Q.m.x + r.x * Q.m.w + r.y * Q.m.z - r.z * Q.m.y,
 	                r.w * Q.m.y - r.x * Q.m.z + r.y * Q.m.w + r.z * Q.m.x,
+	                r.w * Q.m.z + r.x * Q.m.y - r.y * Q.m.x + r.z * Q.m.w,
 	                r.w * Q.m.w - r.x * Q.m.x - r.y * Q.m.y - r.z * Q.m.z));
 }
 


### PR DESCRIPTION
Fix wrong implementation of the geometric antiproduct in multiple functions:

- `Motor3D` * `Motor3D`
- `Motor3D` * `Quaternion`
- `Quaternion` * `Motor3D`

The correct multiplication is taken from PGA Illuminated page 157.

This is the code used to test the functions:

```CPP
const auto R = Terathon::Motor3D::MakeRotation(
	0.2 * 3.141, Terathon::Normalize(Terathon::Bivector3D(1,0.3,-0.05))
);
const auto T = Terathon::Motor3D::MakeTranslation(
	Terathon::Vector3D(0.2, -0.5, 0.1)
);

// first rotate, then translate
auto p_rt = Terathon::Transform(Terathon::Point3D(-1.0, 0.5, 0.5), R);
p_rt = Terathon::Transform(p_rt, T);
// create a motor that first rotates, then translates
// motor * motor
{
	const auto Q = T * R;
	const auto p_q = Terathon::Transform(Terathon::Point3D(-1.0, 0.5, 0.5), Q);
	assert(Terathon::Magnitude(p_rt - p_q) < 0.001);
}
// motor * rotor
{
	auto Q = T * R.v;
	const auto p_q = Terathon::Transform(Terathon::Point3D(-1.0, 0.5, 0.5), Q);
	assert(Terathon::Magnitude(p_rt - p_q) < 0.001);
}

// first translate, then rotate
auto p_tr = Terathon::Transform(Terathon::Point3D(-1.0, 0.5, 0.5), T);
p_tr = Terathon::Transform(p_tr, R);
// motor * motor
{
	auto Q = R * T;
	const auto p_q = Terathon::Transform(Terathon::Point3D(-1.0, 0.5, 0.5), Q);
	assert(Terathon::Magnitude(p_tr - p_q) < 0.001);
}
// rotor * motor
{
	auto Q = R.v * T;
	const auto p_q = Terathon::Transform(Terathon::Point3D(-1.0, 0.5, 0.5), Q);
	assert(Terathon::Magnitude(p_tr - p_q) < 0.001);
}
```